### PR TITLE
Hotfix: Verificación de permisos del usuario en actualización de grupos

### DIFF
--- a/backend/controllers/club_controller.py
+++ b/backend/controllers/club_controller.py
@@ -150,9 +150,10 @@ def update_club_settings(club_id):
     """
     Actualiza los ajustes generales de un club.
     """
-    try:  
+    try:
+        user_id = request.current_user.get('user_id')
         data = request.get_json()
-        success = ClubService.update_club_settings(club_id, data)
+        success = ClubService.update_club_settings(club_id, user_id, data)
         return jsonify({'message':success[0], 'success': success[1]}), 200
     
     except Exception as e:

--- a/backend/services/club_service.py
+++ b/backend/services/club_service.py
@@ -50,7 +50,7 @@ class ClubService:
                 connection.close()
     
     @staticmethod
-    def update_club_settings(club_id: int, settings_data: Dict[str, Any]) -> tuple[str, bool]:
+    def update_club_settings(club_id: int, user_id:int, settings_data: Dict[str, Any]) -> tuple[str, bool]:
         """
         Actualiza los ajustes generales de un club
         """
@@ -67,12 +67,13 @@ class ClubService:
             # Llamar a la función
             cursor.callproc(
                 'public.fn_update_club_settings',
-                (club_id, 
-                 name,
-                 description,
-                 status_id, 
-                 category, 
-                 logo_url))
+                (user_id,
+                club_id, 
+                name,
+                description,
+                status_id, 
+                category, 
+                logo_url))
 
             connection.commit()
             message, success = cursor.fetchall()[0]


### PR DESCRIPTION
## 📌 Descripción

Este *hotfix* asegura que solo los usuarios autorizados —es decir, los **dueños del grupo** o **miembros con rol de administrador (rol_id 2 o 3)**— puedan actualizar los ajustes generales de un club. 

Se corrige la lógica de llamada a la función SQL `fn_update_club_settings`, incorporando el parámetro `user_id` para realizar la verificación de permisos desde la base de datos.

## ✅ Cambios realizados

- Se modifica la función `update_club_settings` en `club_service.py` para incluir `user_id` como parámetro.
- Se actualiza el controlador para extraer `user_id` desde `request.current_user`.
- Se ajusta la llamada a la función PostgreSQL `fn_update_club_settings` para incluir `user_id` como primer parámetro.
- Se refuerza la seguridad para que solo usuarios con permisos puedan modificar la información del grupo.

## 🛠 Archivos modificados

- `backend/controllers/club_controller.py`
- `backend/services/club_service.py`
- `PostgreSQL: fn_update_club_settings` (actualización ya aplicada)
