### PR TITLE
Agregar endpoints para eliminar y reactivar clubs/grupos

### DIFF
--- a/backend/controllers/club_controller.py
+++ b/backend/controllers/club_controller.py
@@ -144,6 +144,39 @@ def upload_group_pfp(club_id):
         return jsonify({"message":"ha ocurrido un error en proceso de subida.", "success":False}), 500
 
 #Administracion
+@jwts.token_required('access')
+def delete_club(club_id):
+    """
+    Elimina un club/grupo.
+    """
+    try:
+        user_id = request.current_user.get('user_id')
+        message, success = ClubService.delete_club_db(club_id, user_id)
+
+        if not success:
+            return jsonify({'message': message, 'success': success}), 400
+        
+        return jsonify({'message': message, 'success': success}), 200
+
+    except Exception as e:
+        return jsonify({'error': 'Error interno del servidor'}), 500
+
+@jwts.token_required('access')
+def reactivate_club(club_id):
+    """
+    Reactiva un club/grupo eliminado.
+    """
+    try:
+        user_id = request.current_user.get('user_id')
+        message, success = ClubService.reactivate_club_db(club_id, user_id)
+
+        if not success:
+            return jsonify({'message': message, 'success': success}), 400
+
+        return jsonify({'message': message, 'success': success}), 200
+
+    except Exception as e:
+        return jsonify({'error': 'Error interno del servidor'}), 500
 
 @jwts.token_required('access')
 def update_club_settings(club_id):

--- a/backend/routes/club_routes.py
+++ b/backend/routes/club_routes.py
@@ -16,7 +16,9 @@ from controllers.club_controller import (
     update_pending_join_request,
     create_club,
     upload_group_pfp,
-    export_club_members
+    export_club_members,
+    delete_club,
+    reactivate_club
 )
 
 # Crear blueprint
@@ -37,3 +39,5 @@ club_bp.route("/api/admin/clubs/<int:club_id>/settings", methods=['PUT'])(update
 club_bp.route("/api/admin/clubs/<int:club_id>/join-requests", methods=['GET'])(club_pending_approval_request)
 club_bp.route("/api/admin/clubs/<int:club_id>/join-requests/<request_id>", methods=['PUT'])(update_pending_join_request)
 club_bp.route('/api/admin/clubs/<int:club_id>/members/export', methods=['GET'])(export_club_members)
+club_bp.route('/api/admin/clubs/<int:club_id>/delete', methods=['PUT'])(delete_club)
+club_bp.route('/api/admin/clubs/<int:club_id>/reactivate', methods=['PUT'])(reactivate_club)

--- a/backend/services/club_service.py
+++ b/backend/services/club_service.py
@@ -193,6 +193,31 @@ class ClubService:
 
 
 #Administracion
+    @staticmethod
+    def reactivate_club_db(club_id: int, user_id: int) -> tuple[str, bool]:
+        """
+        Reactiva un club/grupo eliminado
+        """
+        try:
+            conn = get_connection()
+            cursor = conn.cursor()
+
+            cursor.callproc("public.fn_adm_activate_group", (user_id, club_id))
+
+            conn.commit()
+            message, success = cursor.fetchone()
+
+            return (message, success)
+        
+        except Exception as e:
+            if conn:
+                conn.rollback()
+            return (str(e), False)
+        finally:
+            if cursor:
+                cursor.close()
+            if conn:
+                conn.close()
 
     @staticmethod
     def get_administration_member_status(club_id: int) -> tuple[str, bool]:
@@ -356,6 +381,32 @@ class ClubService:
                 'success': False,
                 'was_approved': None,
                 'approved_user_data': None}
+        finally:
+            if cursor:
+                cursor.close()
+            if conn:
+                conn.close()
+    
+    @staticmethod
+    def delete_club_db(club_id: int, user_id: int) -> tuple[str, bool]:
+        """
+        Elimina un club/grupo de la base de datos
+        """
+        try:
+            conn = get_connection()
+            cursor = conn.cursor()
+
+            cursor.callproc("public.fn_adm_delete_group", (user_id, club_id))
+
+            conn.commit()
+            message, success = cursor.fetchone()
+
+            return (message, success)
+        
+        except Exception as e:
+            if conn:
+                conn.rollback()
+            return (str(e), False)
         finally:
             if cursor:
                 cursor.close()

--- a/backend/utils/security.py
+++ b/backend/utils/security.py
@@ -24,14 +24,14 @@ def cookies_config() -> dict:
 def auth_token_ttl():
     """Tiempo de vida del token de acceso
     Devuelve el tiempo de vida del token de acceso en segundos."""
-    return os.getenv('ACCESS_TOKEN_EXPIRES', 900) #default 15 minutos
+    return int(os.getenv('ACCESS_TOKEN_EXPIRES', 900)) #default 15 minutos
 
 def reset_token_ttl():
     """Tiempo de vida del token de restablecimiento de contraseña
     Devuelve el tiempo de vida del token de restablecimiento de contraseña en segundos."""
-    return os.getenv('RESET_PASS_TOKEN_EXPIRES', 600) #default 10 minutos
+    return int(os.getenv('RESET_PASS_TOKEN_EXPIRES', 600)) #default 10 minutos
 
 def refresh_token_ttl():
     """Tiempo de vida del token de actualización
     Devuelve el tiempo de vida del token de actualización en segundos."""
-    return os.getenv('REFRESH_TOKEN_EXPIRES', 604800) #default 7 dias
+    return int(os.getenv('REFRESH_TOKEN_EXPIRES', 604800)) #default 7 dias


### PR DESCRIPTION
Este PR agrega la funcionalidad para que un administrador pueda eliminar o reactivar un club/grupo desde la administración. También se ajustan algunas funciones relacionadas con la conversión de valores de tiempo en las configuraciones de tokens.

---

### 🆕 Cambios introducidos

#### 📁 `backend/routes/club_routes.py`
- Se importan los nuevos controladores: `delete_club` y `reactivate_club`.
- Se agregan nuevas rutas:
  - `PUT /api/admin/clubs/<int:club_id>/delete` → Eliminar club.
  - `PUT /api/admin/clubs/<int:club_id>/reactivate` → Reactivar club.

#### 📁 `backend/services/club_service.py`
- ✅ `delete_club_db(club_id, user_id)`:
  - Ejecuta el procedimiento almacenado `fn_adm_delete_group`.
- ✅ `reactivate_club_db(club_id, user_id)`:
  - Ejecuta el procedimiento almacenado `fn_adm_activate_group`.

#### 📁 `backend/utils/security.py`
- Se asegura que los valores de expiración de los tokens sean convertidos a `int`.