### PR TITLE
 Obtener todos los clubes

### DIFF
--- a/backend/controllers/club_controller.py
+++ b/backend/controllers/club_controller.py
@@ -82,6 +82,19 @@ def create_club():
             'message': 'Error del servidor al procesar la solicitud'
         }), 500
 
+@jwts.token_required('access')
+def get_all_clubs():
+    """
+    Obtiene todos los clubes/grupos disponibles.
+    """
+    try:
+        clubs = ClubService.get_all_clubs()
+        if not clubs:
+            return jsonify({'message': 'No hay clubes disponibles.', 'success': True}), 404
+        
+        return jsonify({'clubs_list': clubs}), 200
+    except Exception as e:
+        return jsonify({'error': 'Error interno del servidor'}), 500
 
 
 @jwts.token_required('access')

--- a/backend/routes/club_routes.py
+++ b/backend/routes/club_routes.py
@@ -18,7 +18,8 @@ from controllers.club_controller import (
     upload_group_pfp,
     export_club_members,
     delete_club,
-    reactivate_club
+    reactivate_club,
+    get_all_clubs
 )
 
 # Crear blueprint
@@ -29,6 +30,7 @@ club_bp.route("/api/groups/<int:club_id>", methods=['GET'])(get_club_details)
 club_bp.route("/api/users/me/groups", methods=['GET'])(get_club_by_user)
 club_bp.route("/api/groups/<int:club_id>/join", methods=['POST'])(request_join_group)
 club_bp.route("/api/groups", methods= ['POST'])(create_club)
+club_bp.route("/api/groups", methods=['GET'])(get_all_clubs)
 club_bp.route("/api/groups/<int:club_id>/photo", methods=['PUT'])(upload_group_pfp)
 #Administración
 club_bp.route("/api/admin/clubs/<int:club_id>/members/stats", methods=['GET'])(get_member_stats)

--- a/backend/services/club_service.py
+++ b/backend/services/club_service.py
@@ -90,6 +90,45 @@ class ClubService:
             if connection:
                 connection.close()
 
+    @staticmethod
+    def get_all_clubs():
+        """
+        Obtiene todos los clubes/grupos disponibles
+        """
+        try:
+            connection = get_connection()
+            cursor = connection.cursor()
+            
+            cursor.callproc('public.fn_get_all_clubs')
+            clubs = cursor.fetchall()
+
+            result = []
+            for club in clubs:
+                result.append({
+                    'group_id': club[0],
+                    'group_name': club[1],
+                    'group_description': club[2],
+                    'owner_name': club[3],
+                    'creation_date': club[4].isoformat() if club[4] else None,
+                    'logo_url': club[5],
+                    'group_type_name': club[6],
+                    'group_status_name': club[7],
+                    'members_count': club[8]
+                })
+            
+            cursor.close()
+            connection.close()
+            return result
+            
+        except Exception as e:
+            print(f"Error getting all clubs: {e}")
+            return []
+        finally:
+            if cursor:
+                cursor.close()
+            if connection:
+                connection.close()
+
     @staticmethod   
     def get_user_related_groups(user_id:int) -> Optional[list[Dict[str, Any]]]:
         """Obtiene los grupos relacionados al usuario por user_id"""


### PR DESCRIPTION
#### 📁 `backend/routes/club_routes.py`

- Se agrega el controlador `get_all_clubs` al import.
- Se define nueva ruta:
  - `GET /api/groups` → Obtener todos los clubes/grupos disponibles para usuarios autenticados.

#### 📁 `backend/services/club_service.py`

- Se añade el método `get_all_clubs()` en `ClubService`, que ejecuta el procedimiento almacenado `fn_get_all_clubs`.