### PR TITLE
Delegar envío de código de verificación a listener en la base de datos

### DIFF
--- a/backend/controllers/auth_controller.py
+++ b/backend/controllers/auth_controller.py
@@ -4,7 +4,6 @@ from services import auth_service
 from services.jwt_service import JWTService as jwts
 from emails.email_types import verification_code_email as vce
 from emails.email_types import welcome
-import threading
 
 #Constantes
 REFRESH_TOKEN_EXPIRES = auth_service.refresh_token_ttl()
@@ -153,23 +152,26 @@ def logout() ->tuple:
 
 def create_user() -> tuple:
     """
-    Creación de usuario
+    Creacion de usuario
     """
     data = request.get_json()
 
     message, success = auth_service.create_user_db(data)
 
     if success:
-        full_name = f'{data.get("firstName", "")} {data.get("lastName", "")}'.strip()
+        full_name = f'{data.get("firstName")} {data.get("lastName")}'.strip()
         email = data.get('email', '')
-
-        # Envío en segundo plano
-        threading.Thread(target=welcome.send_welcome_email, args=(email, full_name)).start()
-
-        return jsonify({
-            "message": message,
-            "success": True
-        }), 201
+        if welcome.send_welcome_email(recipient=email, user_name=full_name):
+            return jsonify({
+                "message": message,
+                "success": True
+            }), 201
+        
+        else:
+            return jsonify({
+                "message": 'usuario creado exitosamente. Fallo en la mensajeria.',
+                "success": True
+            }), 201
 
     else:
         return jsonify({
@@ -194,10 +196,8 @@ def user_forgot_password():
 
     if not inserted:
         return jsonify({'message': 'No se pudo generar el código.', 'success': False}), 500
-    
+  
     reset_token = jwts.create_token(user_data={'email': email}, expires_in=RESET_PASS_TOKEN_EXPIRES, type='reset_pass')
-
-    threading.Thread(target=vce.send_verification_email, args=(email, code)).start()
 
     return jsonify({'message': 'codigo enviado exitosamente.', 'token': reset_token,'success': True}), 200
 

--- a/backend/controllers/notifications_controller.py
+++ b/backend/controllers/notifications_controller.py
@@ -1,6 +1,7 @@
 from emails.email_types.activity_cancelled import send_activity_cancel_email
 from emails.email_types.activity_reminder import send_activity_reminder_email
 from emails.email_types.activity_created import send_activity_created_email
+from emails.email_types.verification_code_email import send_verification_email
 from app import app
 from flask import current_app
 
@@ -31,6 +32,8 @@ class ProcessNotifications:
                     self._handle_activity_created()
                 case 'activity_reminder':
                     self._handle_activity_reminder()
+                case 'reset_pass_code':
+                    self._handle_reset_pass_code()
                 case _:
                     print(f"Contexto desconocido: {self.context}")
 
@@ -82,3 +85,13 @@ class ProcessNotifications:
                     activity_name=activity_name,
                     group_name=group_name
                 )
+    
+    def _handle_reset_pass_code(self):
+        """ Maneja el envío de correos electrónicos para el restablecimiento de contraseña.
+        Extrae los datos necesarios del contexto y envía un correo electrónico con el código de verificación."""
+        email = self.data.get('email')
+        code = self.data.get('code')
+        if email and code:
+            send_verification_email(email, code)
+
+    


### PR DESCRIPTION
#### 📋 Descripción

Este refactor cambia la responsabilidad del envío del código de verificación cuando un usuario solicita recuperar su contraseña.

- En lugar de que la aplicación Flask envíe directamente el correo electrónico, ahora la base de datos es responsable de notificar este evento mediante un **listener**.
- El listener ejecuta un hilo independiente que se encarga de llamar a la función de envío de correo para el código de verificación.
- De este modo, la aplicación backend se libera de la tarea de enviar el correo directamente, mejorando la escalabilidad y desacoplando la lógica de notificaciones.
- Para otros correos (como bienvenida al crear usuario) se hace el mismo tipo de refactor.

#### 🔧 Cambios principales

- Se agregó el controlador `_handle_reset_pass_code` en el listener para procesar el evento de código de restablecimiento.
- Se ajustaron constantes y funciones para reflejar correctamente esta nueva arquitectura de notificaciones.

#### ⚙️ Beneficios

- **Desacoplamiento:** La base de datos controla la notificación, y el backend solo procesa eventos.
- **Escalabilidad:** Se puede manejar mejor la carga de notificaciones sin afectar el flujo principal.
- **Concurrencia:** Uso de hilos para envío sin bloquear.

#### 📌 Consideraciones

- El backend sigue siendo responsable de crear y almacenar el código de verificación en base de datos.
- Los eventos de notificación se manejan en el módulo `notifications_controller.py`.

