### PR TITLE
Soporte para múltiples orígenes en configuración CORS

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -36,8 +36,9 @@ app.config['MAIL_DEFAULT_SENDER'] = os.getenv("MAIL_DEFAULT_SENDER", "no-reply@l
 init_mail(app)
 
 #CORS
-frontend_origin = os.getenv('FRONTEND_ORIGIN')
-CORS(app, resources={r"/api/*": {'origins': frontend_origin}}, supports_credentials=True)
+frontend_origins = os.getenv('FRONTEND_ORIGIN', '')
+allowed_origins = [origin.strip() for origin in frontend_origins.split(',') if origin.strip()]
+CORS(app, resources={r"/api/*": {'origins': allowed_origins}}, supports_credentials=True)
 
 #BluePrints
 app.register_blueprint(auth_bp)

--- a/backend/controllers/auth_controller.py
+++ b/backend/controllers/auth_controller.py
@@ -233,6 +233,6 @@ def reset_password_via_code():
     update_result = auth_service.reset_password(email=email, new_password=hashed_password)
 
     if not update_result:
-        return jsonify({"message": 'error al actualizar contraseña.', 'success':False})
+        return jsonify({"message": 'error al actualizar contraseña.', 'success':False}), 500
     
     return update_result


### PR DESCRIPTION
### Descripción

Este cambio mejora la configuración de CORS en la aplicación Flask:

- Se añade soporte para múltiples orígenes utilizando la variable de entorno `FRONTEND_ORIGIN`, permitiendo definirlos como una lista separada por comas (por ejemplo: `http://localhost:3000,https://miapp.com`).
- Se genera dinámicamente la lista `allowed_origins` a partir de esa variable.
- Se aplica esta lista en la configuración de CORS para el recurso `/api/*`, habilitando también `supports_credentials=True`.

### Código relevante

```python
frontend_origins = os.getenv('FRONTEND_ORIGIN', '')
allowed_origins = [origin.strip() for origin in frontend_origins.split(',') if origin.strip()]
CORS(app, resources={r"/api/*": {'origins': allowed_origins}}, supports_credentials=True)
